### PR TITLE
fix |> 修复 Long Long 等 64 位类型绑定缺陷

### DIFF
--- a/CTPersistance/CTPersistance/Categories/NSMutableArray/CTPersistanceBindValue/NSMutableArray+CTPersistanceBindValue.m
+++ b/CTPersistance/CTPersistance/Categories/NSMutableArray/CTPersistanceBindValue/NSMutableArray+CTPersistanceBindValue.m
@@ -156,7 +156,7 @@
     }
 
     if ([value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSString class]]) {
-        sqlite3_bind_int(statement, sqlite3_bind_parameter_index(statement, [key UTF8String]), [value intValue]);
+        sqlite3_bind_int64(statement, sqlite3_bind_parameter_index(statement, [key UTF8String]), [value longLongValue]);
         return;
     }
 }

--- a/CTPersistance/CTPersistance/QueryCommand/Categories/SchemaManipulations/CTPersistanceQueryCommand+SchemaManipulations.h
+++ b/CTPersistance/CTPersistance/QueryCommand/Categories/SchemaManipulations/CTPersistanceQueryCommand+SchemaManipulations.h
@@ -21,6 +21,17 @@
 - (CTPersistanceSqlStatement *)createTable:(NSString *)tableName columnInfo:(NSDictionary *)columnInfo;
 
 /**
+ *  create table with column information and defaultVaule
+ *
+ *  @param tableName  name of table
+ *  @param columnInfo colomn information of table
+ *  @param defaultSetting colomn default value information of table
+
+ *  @return return CTPersistanceQueryCommand
+ */
+- (CTPersistanceSqlStatement *)createTable:(NSString *)tableName columnInfo:(NSDictionary *)columnInfo columnDefaultValue:(NSDictionary *)defaultSetting;
+
+/**
  *  drop table with table name
  *
  *  @param tableName name of table

--- a/CTPersistance/CTPersistance/QueryCommand/Categories/SchemaManipulations/CTPersistanceQueryCommand+SchemaManipulations.m
+++ b/CTPersistance/CTPersistance/QueryCommand/Categories/SchemaManipulations/CTPersistanceQueryCommand+SchemaManipulations.m
@@ -38,6 +38,50 @@
     return [self compileSqlString:sqlString bindValueList:nil error:NULL];
 }
 
+/**
+ *  create table with column information and defaultVaule
+ *
+ *  @param tableName  name of table
+ *  @param columnInfo colomn information of table
+ *  @param defaultSetting colomn default value information of table
+
+ *  @return return CTPersistanceQueryCommand
+ */
+- (CTPersistanceSqlStatement *)createTable:(NSString *)tableName columnInfo:(NSDictionary *)columnInfo columnDefaultValue:(NSDictionary *)defaultSetting{
+
+    if (CTPersistance_isEmptyString(tableName)) {
+        return nil;
+    }
+
+    NSMutableArray *columnList = [[NSMutableArray alloc] init];
+
+    [columnInfo enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull columnName, NSString * _Nonnull columnDescription, BOOL * _Nonnull stop) {
+        id defaultValue = [defaultSetting valueForKey:columnName];
+
+        if ([defaultValue isKindOfClass:[NSString class]]) {
+            defaultValue = [NSString stringWithFormat:@"'%@'",defaultValue];
+        }
+        
+        NSString *defaultSetting = @"";
+        if(defaultValue) {
+            defaultSetting = [NSString stringWithFormat:@"DEFAULT %@",defaultValue];
+        }
+
+        if (CTPersistance_isEmptyString(columnDescription)) {
+            [columnList addObject:[NSString stringWithFormat:@"`%@` %@", columnName, defaultSetting]];
+        } else {
+            [columnList addObject:[NSString stringWithFormat:@"`%@` %@ %@", columnName, columnDescription, defaultSetting]];
+        }
+    }];
+
+    NSString *columns = [columnList componentsJoinedByString:@","];
+
+    NSString *sqlString = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS `%@` (%@);", tableName, columns];
+
+    return [self compileSqlString:sqlString bindValueList:nil error:NULL];
+}
+
+
 - (CTPersistanceSqlStatement *)dropTable:(NSString *)tableName
 {
     if (CTPersistance_isEmptyString(tableName)) {

--- a/CTPersistance/CTPersistance/Record/CTPersistanceRecord.m
+++ b/CTPersistance/CTPersistance/Record/CTPersistanceRecord.m
@@ -32,11 +32,26 @@
     
     NSMutableDictionary *dictionaryRepresentation = [[NSMutableDictionary alloc] init];
     [table.columnInfo enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull columnName, NSString * _Nonnull columnDescription, BOOL * _Nonnull stop) {
-        if (propertyList[columnName]) {
-            dictionaryRepresentation[columnName] = propertyList[columnName];
+        if (!propertyList[columnName]) {
+            return;
+        }
+
+        dictionaryRepresentation[columnName] = propertyList[columnName];
+
+        if (propertyList[columnName] != [NSNull null]) {
+            return;
+        }
+
+        //setting default value
+        if(table.columnDetaultValue) {
+            id defaultValue = [table.columnDetaultValue valueForKey:columnName];
+
+            if(defaultValue) {
+                dictionaryRepresentation[columnName] = defaultValue;
+            }
         }
     }];
-    
+
     return dictionaryRepresentation;
 }
 

--- a/CTPersistance/CTPersistance/Table/CTPersistanceTable.h
+++ b/CTPersistance/CTPersistance/Table/CTPersistanceTable.h
@@ -54,6 +54,24 @@
 - (NSString *)primaryKeyName;
 
 @optional
+
+/**
+ *  column default value with this table.
+ *  suport base type: INTEGER、TEXT、REAL
+ *  For Example:
+
+ return return @{
+            @"defaultInt":@"0",
+            @"defaultStr":@"",
+            @"defaultBool":@"1"
+ };
+
+ This is mean defaultInt = 0、defaultStr = '' and defaultBool = 1
+ *
+ *  @return return the column default value of your table
+ */
+-(NSDictionary *)columnDetaultValue;
+
 /**
  *  to check record before insert
  *

--- a/CTPersistance/CTPersistance/Table/CTPersistanceTable.m
+++ b/CTPersistance/CTPersistance/Table/CTPersistanceTable.m
@@ -68,9 +68,13 @@ NSString * const kCTPersistanceTableIndexIsUniq = @"kCTPersistanceTableIndexIsUn
 - (void)configTable:(CTPersistanceQueryCommand *)queryCommand
 {
     __block NSError *error = nil;
-    
+
     // create table if not exists
-    [[queryCommand createTable:self.child.tableName columnInfo:self.child.columnInfo] executeWithError:&error];
+    if(self.child.columnDetaultValue) {
+        [[queryCommand createTable:self.child.tableName columnInfo:self.child.columnInfo columnDefaultValue:self.child.columnDetaultValue] executeWithError:&error];
+    } else {
+        [[queryCommand createTable:self.child.tableName columnInfo:self.child.columnInfo] executeWithError:&error];
+    }
     
     // create index if not exists
     if (error == nil) {
@@ -102,6 +106,10 @@ NSString * const kCTPersistanceTableIndexIsUniq = @"kCTPersistanceTableIndexIsUn
 }
 
 #pragma mark - method to override
+-(NSDictionary *)columnDetaultValue {
+    return nil;
+}
+
 - (NSArray <NSDictionary *> *)indexList
 {
     return nil;

--- a/CTPersistance/CTPersistance/Table/Categories/Insert/CTPersistanceTable+Insert.m
+++ b/CTPersistance/CTPersistance/Table/Categories/Insert/CTPersistanceTable+Insert.m
@@ -65,6 +65,7 @@ static NSString * const kCTPersistanceErrorUserinfoKeyErrorRecord = @"kCTPersist
 
 - (NSNumber *)insertValue:(id)value forKey:(NSString *)key error:(NSError *__autoreleasing *)error
 {
+
     if (value == nil) {
         value = [NSNull null];
     }
@@ -72,7 +73,15 @@ static NSString * const kCTPersistanceErrorUserinfoKeyErrorRecord = @"kCTPersist
     if (key == nil) {
         return nil;
     }
-    
+
+    if(self.child.columnDetaultValue && value == [NSNull null]  ) {
+        id defaultVale = [self.child.columnDetaultValue valueForKey:key];
+
+        if(defaultVale) {
+            value = defaultVale;
+        }
+    }
+
     BOOL result = [[self.queryCommand insertTable:self.child.tableName columnInfo:self.child.columnInfo dataList:@[@{key:value}] error:error] executeWithError:error];
     if (result) {
         return [self.queryCommand lastInsertRowId];

--- a/CTPersistanceTests/CTPersistanceTestInsert.m
+++ b/CTPersistanceTests/CTPersistanceTestInsert.m
@@ -111,23 +111,6 @@
     XCTAssertNotNil([self.testTable findWithPrimaryKey:record.primaryKey error:NULL]);
 }
 
-- (void)testInsertLongLongTypeRecord {
-    NSDate *now = [NSDate date];
-    long long millisecond = [now timeIntervalSince1970] * 1000;
-
-    TestRecord *record = [[TestRecord alloc] init];
-    record.timeStamp = millisecond;
-
-    NSError *error = nil;
-    [self.testTable insertRecord:record error:&error];
-    XCTAssertNil(error);
-
-    TestRecord *existRecord = (TestRecord*)[self.testTable findWithPrimaryKey:record.primaryKey error:&error];
-    XCTAssertNil(error);
-    XCTAssertNotNil(existRecord);
-    XCTAssert(existRecord.timeStamp == millisecond);
-}
-
 - (void)testInsertRecordList
 {
     NSInteger recordCount = 10;
@@ -147,6 +130,38 @@
         [primaryList addObject:obj.primaryKey];
     }];
     XCTAssertEqual(recordList.count, [self.testTable findAllWithPrimaryKey:primaryList error:NULL].count);
+}
+
+- (void)testInsertLongLongTypeRecord {
+    NSDate *now = [NSDate date];
+    long long millisecond = [now timeIntervalSince1970] * 1000;
+
+    TestRecord *record = [[TestRecord alloc] init];
+    record.timeStamp = millisecond;
+
+    NSError *error = nil;
+    [self.testTable insertRecord:record error:&error];
+    XCTAssertNil(error);
+
+    TestRecord *existRecord = (TestRecord*)[self.testTable findWithPrimaryKey:record.primaryKey error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(existRecord);
+    XCTAssert(existRecord.timeStamp == millisecond);
+}
+
+- (void)testDefaultInsert {
+    TestRecord *record = [[TestRecord alloc] init];
+    
+    NSError *error = nil;
+    [self.testTable insertRecord:record error:&error];
+    XCTAssertNil(error);
+
+    TestRecord *existRecord = (TestRecord*)[self.testTable findWithPrimaryKey:record.primaryKey error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(existRecord);
+
+    XCTAssert([existRecord.defaultStr isEqualToString:@""]);
+
 }
 
 //- (void)testInsert_100_Performance

--- a/CTPersistanceTests/CTPersistanceTestInsert.m
+++ b/CTPersistanceTests/CTPersistanceTestInsert.m
@@ -21,6 +21,8 @@
 - (void)setUp {
     [super setUp];
     self.testTable = [[TestTable alloc] init];
+ 
+
 }
 
 - (void)tearDown {

--- a/CTPersistanceTests/CTPersistanceTestInsert.m
+++ b/CTPersistanceTests/CTPersistanceTestInsert.m
@@ -109,6 +109,23 @@
     XCTAssertNotNil([self.testTable findWithPrimaryKey:record.primaryKey error:NULL]);
 }
 
+- (void)testInsertLongLongTypeRecord {
+    NSDate *now = [NSDate date];
+    long long millisecond = [now timeIntervalSince1970] * 1000;
+
+    TestRecord *record = [[TestRecord alloc] init];
+    record.timeStamp = millisecond;
+
+    NSError *error = nil;
+    [self.testTable insertRecord:record error:&error];
+    XCTAssertNil(error);
+
+    TestRecord *existRecord = (TestRecord*)[self.testTable findWithPrimaryKey:record.primaryKey error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(existRecord);
+    XCTAssert(existRecord.timeStamp == millisecond);
+}
+
 - (void)testInsertRecordList
 {
     NSInteger recordCount = 10;

--- a/CTPersistanceTests/CTPersistanceTestUpdate.m
+++ b/CTPersistanceTests/CTPersistanceTestUpdate.m
@@ -33,6 +33,11 @@
         record.avatar = [@"avatar" dataUsingEncoding:NSUTF8StringEncoding];
         record.progress = @(0.0f);
         record.isCelebrity = @(NO);
+
+        NSDate *now = [NSDate date];
+        long long millisecond = [now timeIntervalSince1970] * 1000;
+        record.timeStamp = millisecond;
+
         [self.testTable insertRecord:record error:NULL];
         [self.recordList addObject:record];
         [self.primaryKeyList addObject:record.primaryKey];
@@ -148,6 +153,32 @@
                                  error:&error];
     XCTAssertNil(error);
 
+    NSArray <TestRecord *> *recordListToCheck = (NSArray <TestRecord *> *)[self.testTable findAllWithPrimaryKey:self.primaryKeyList error:NULL];
+    XCTAssertEqual(recordListToCheck.count, self.primaryKeyList.count);
+    [recordListToCheck enumerateObjectsUsingBlock:^(TestRecord * _Nonnull recordToCheck, NSUInteger idx, BOOL * _Nonnull stop) {
+        XCTAssert([recordToCheck.name isEqualToString:@"testUpdateKeyValueListWhereConditionWhereConditionParams"]);
+        NSString *newAvatarString = [[NSString alloc] initWithData:recordToCheck.avatar encoding:NSUTF8StringEncoding];
+        XCTAssert([newAvatarString isEqualToString:@"newAvatar"]);
+        XCTAssertEqual([recordToCheck.progress doubleValue], 0.1f);
+    }];
+}
+
+- (void)testUpdateKeyValueListWithLongLongTypeWhereCondition {
+    NSError *error = nil;
+
+    NSDate *now = [NSDate date];
+    long long millisecond = [now timeIntervalSince1970] * 1000;
+
+
+    [self.testTable updateKeyValueList:@{
+                                         @"name":@"testUpdateKeyValueListWhereConditionWhereConditionParams",
+                                         @"avatar":[@"newAvatar" dataUsingEncoding:NSUTF8StringEncoding],
+                                         @"progress":@(0.1f)
+                                         }
+                        whereCondition:@"timeStamp < :timeStamp"
+                  whereConditionParams:@{@":timeStamp":@(millisecond + 1),}
+                                 error:&error];
+    XCTAssertNil(error);
     NSArray <TestRecord *> *recordListToCheck = (NSArray <TestRecord *> *)[self.testTable findAllWithPrimaryKey:self.primaryKeyList error:NULL];
     XCTAssertEqual(recordListToCheck.count, self.primaryKeyList.count);
     [recordListToCheck enumerateObjectsUsingBlock:^(TestRecord * _Nonnull recordToCheck, NSUInteger idx, BOOL * _Nonnull stop) {

--- a/CTPersistanceTests/CTPersistanceTestUpdate.m
+++ b/CTPersistanceTests/CTPersistanceTestUpdate.m
@@ -242,4 +242,33 @@
     }];
 }
 
+- (void)testUpdateWithDefaultValue {
+    NSError *error = nil;
+
+    TestRecord *record = (TestRecord *)[self.testTable findWithPrimaryKey:@(1) error:&error];
+    XCTAssertNil(error);
+
+    // Default String
+    record.defaultStr = nil;
+    [self.testTable updateRecord:record error:&error];
+    XCTAssertNil(error);
+    TestRecord *existRecord = (TestRecord *)[self.testTable findWithPrimaryKey:@(1) error:&error];
+    XCTAssertNil(error);
+    XCTAssert([existRecord.defaultStr isEqualToString:@""]);
+
+    // Default Int
+    [self.testTable updateValue:nil forKey:@"defaultInt" primaryKeyValue:@(1)  error:&error];
+    XCTAssertNil(error);
+    existRecord = (TestRecord *)[self.testTable findWithPrimaryKey:@(1) error:&error];
+    XCTAssertNil(error);
+    XCTAssert(existRecord.defaultInt == 1);
+
+    // Default Int
+    [self.testTable updateValue:nil forKey:@"defaultDouble" primaryKeyValue:@(1)  error:&error];
+    XCTAssertNil(error);
+    existRecord = (TestRecord *)[self.testTable findWithPrimaryKey:@(1) error:&error];
+    XCTAssertNil(error);
+    XCTAssert(existRecord.defaultDouble == 1);
+
+}
 @end

--- a/CTPersistanceTests/TestModel/Record/TestRecord.h
+++ b/CTPersistanceTests/TestModel/Record/TestRecord.h
@@ -17,5 +17,8 @@
 @property (nonatomic, strong) NSNumber *progress;
 @property (nonatomic, strong) NSNumber *isCelebrity;
 @property (nonatomic, assign) long long timeStamp;
+@property (nonatomic, assign) NSInteger defaultInt;
+@property (nonatomic, strong) NSString  *defaultStr;
+@property (nonatomic, assign) BOOL      defaultBool;
 
 @end

--- a/CTPersistanceTests/TestModel/Record/TestRecord.h
+++ b/CTPersistanceTests/TestModel/Record/TestRecord.h
@@ -20,5 +20,5 @@
 @property (nonatomic, assign) NSInteger defaultInt;
 @property (nonatomic, strong) NSString  *defaultStr;
 @property (nonatomic, assign) BOOL      defaultBool;
-
+@property (nonatomic, assign) double    defaultDouble;
 @end

--- a/CTPersistanceTests/TestModel/Record/TestRecord.h
+++ b/CTPersistanceTests/TestModel/Record/TestRecord.h
@@ -16,5 +16,6 @@
 @property (nonatomic, strong) NSData *avatar;
 @property (nonatomic, strong) NSNumber *progress;
 @property (nonatomic, strong) NSNumber *isCelebrity;
+@property (nonatomic, assign) long long timeStamp;
 
 @end

--- a/CTPersistanceTests/TestModel/Table/TestTable.m
+++ b/CTPersistanceTests/TestModel/Table/TestTable.m
@@ -28,9 +28,10 @@
 
 -(NSDictionary *)columnDetaultValue {
     return @{
-             @"defaultInt":@"0",
+             @"defaultInt":@(1),
              @"defaultStr":@"",
-             @"defaultBool":@"1"
+             @"defaultBool":@(1),
+             @"defaultDouble":@(1.0)
              };
 }
 
@@ -45,8 +46,10 @@
              @"progress":@"REAL",
              @"timeStamp":@"INTEGER",
              @"defaultInt":@"INTEGER",
-             @"defaultStr":@"TEXT NOT NULL",
-             @"defaultBool":@"INTEGER"
+             @"defaultStr":@"TEXT",
+             @"defaultBool":@"INTEGER",
+             @"defaultDouble":@"REAL",
+             @"defaultBlob":@"BLOB"
              };
 }
 

--- a/CTPersistanceTests/TestModel/Table/TestTable.m
+++ b/CTPersistanceTests/TestModel/Table/TestTable.m
@@ -34,7 +34,8 @@
              @"age":@"INTEGER",
              @"isCelebrity":@"BOOLEAN",
              @"avatar":@"BLOB",
-             @"progress":@"REAL"
+             @"progress":@"REAL",
+             @"timeStamp":@"INTEGER"
              };
 }
 

--- a/CTPersistanceTests/TestModel/Table/TestTable.m
+++ b/CTPersistanceTests/TestModel/Table/TestTable.m
@@ -26,6 +26,14 @@
     
 }
 
+-(NSDictionary *)columnDetaultValue {
+    return @{
+             @"defaultInt":@"0",
+             @"defaultStr":@"",
+             @"defaultBool":@"1"
+             };
+}
+
 - (NSDictionary *)columnInfo
 {
     return @{
@@ -35,7 +43,10 @@
              @"isCelebrity":@"BOOLEAN",
              @"avatar":@"BLOB",
              @"progress":@"REAL",
-             @"timeStamp":@"INTEGER"
+             @"timeStamp":@"INTEGER",
+             @"defaultInt":@"INTEGER",
+             @"defaultStr":@"TEXT NOT NULL",
+             @"defaultBool":@"INTEGER"
              };
 }
 


### PR DESCRIPTION
原有 bindIntegerWithStatement 中存在缺陷会导致 64 为整型数据精度丢失。因此会导致 64 为整型相关的 CRUD 操作出现异常行为。