### PR TITLE
fix |> iOS 8.2 之前版本 SQLite 关闭问题

### DIFF
--- a/CTPersistance/CTPersistance/Database/CTPersistanceDataBase.m
+++ b/CTPersistance/CTPersistance/Database/CTPersistanceDataBase.m
@@ -104,7 +104,12 @@ NSString * const kCTPersistanceConfigurationParamsKeyDatabaseName = @"kCTPersist
 #pragma mark - public methods
 - (void)closeDatabase
 {
-    sqlite3_close_v2(_database);
+    if (@available(iOS 8.2, *)) {
+        sqlite3_close_v2(_database);
+    } else {
+        sqlite3_close(_database);
+    }
+    
     _database = NULL;
     _databaseFilePath = nil;
 }


### PR DESCRIPTION
1. closeDatabase 中 sqlite3_close_v2 只在 8.2 之后版本中有用