### PR TITLE
sql语句中有汉字时result=SQLITE_ERROR

### DIFF
--- a/CTPersistance.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CTPersistance.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CTPersistance/CTPersistance/QueryCommand/Statement/CTPersistanceSqlStatement.m
+++ b/CTPersistance/CTPersistance/QueryCommand/Statement/CTPersistanceSqlStatement.m
@@ -26,7 +26,7 @@
         self.database = database;
 #warning todo statement cache
         sqlite3_stmt *statement = nil;
-        int result = sqlite3_prepare_v2(database.database, [sqlString UTF8String], (int)sqlString.length, &statement, NULL);
+        int result = sqlite3_prepare_v2(database.database, [sqlString UTF8String], (int)[sqlString lengthOfBytesUsingEncoding:NSUTF8StringEncoding], &statement, NULL);
 
         if (result != SQLITE_OK) {
             self.statement = nil;


### PR DESCRIPTION
当sqlString中有汉字时，sqlString.length != [sqlString UTF8String]的字节长度（汉字UTF8编码中占两个字节）。
所以这里应该是(int)[sqlString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]，或像前一个版本一样写成-1