### PR TITLE
线程同步，增加同步读操作

### DIFF
--- a/CTPersistance/CTPersistance/Async/CTPersistanceAsyncExecutor.h
+++ b/CTPersistance/CTPersistance/Async/CTPersistanceAsyncExecutor.h
@@ -24,4 +24,6 @@
 
 - (void)read:(void (^)(void))readAction;
 
+- (void)syncRead:(void (^)(void))readAction;
+
 @end

--- a/CTPersistance/CTPersistance/Async/CTPersistanceAsyncExecutor.m
+++ b/CTPersistance/CTPersistance/Async/CTPersistanceAsyncExecutor.m
@@ -55,4 +55,10 @@
     });
 }
 
+- (void)syncRead:(void (^)(void))readAction {
+    dispatch_sync(self.queue, ^{
+        readAction();
+    });
+}
+
 @end


### PR DESCRIPTION
使用过程中碰到一些线程同步的问题
目前是跟Demo中一样的架构，把对Table的操作封装到DataCenter对象中，如下图
![2019-03-05 11 32 19](https://user-images.githubusercontent.com/10241716/53779224-5cdab180-3f3a-11e9-8dc3-57298d07f182.png)
但是问题是外部调用dataCenter的入口线程不好控制，有些写操作可能是在异步线程、有些读可能在主线程，项目复杂的情况下，会出现读的时候正在写入，导致读取操作报错（database file locked类似的报错）

现在是想在dataCenter里面做线程同步，写操作放到 [[CTPersistanceAsyncExecutor sharedInstance] write:^{里面执行，这里是OK的
但是读操作就比较尴尬了，因为读操作是异步的，导致dataCenter里面的读操作也要写成异步返回数据库的读取结果，如果想写成结果同步返回，只能使用信号量之类的同步措施：
`/**
 *  从本地读取全部表数据
 */
- (NSArray <HikConversationRecord *> *)fetchTableList {
    __block NSArray *fetchedRecordList;
    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
    [[CTPersistanceAsyncExecutor sharedInstance] read:^{
        NSError *error = nil;
        fetchedRecordList = [self.conversationTable findAllWithError:&error];
        
        dispatch_semaphore_signal(sema);

        NSAssert(error == nil, [error localizedDescription]);
    }];
    
    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);

    return fetchedRecordList;
}`
代码很难看，所以想是否可以开放一个同步读取的操作，使dataCenter里面的读操作既能避免多线程读写操作的冲突、又能保证读操作能同步返回，如下：
`
//同步读取方法
- (void)syncRead:(void (^)(void))readAction {
    dispatch_sync(self.queue, ^{
        readAction();
    });
}

/**
 *  从本地读取全部表数据
 */
- (NSArray <HikConversationRecord *> *)fetchTableList {
    __block NSArray *fetchedRecordList;
    [[CTPersistanceAsyncExecutor sharedInstance] syncRead:^{
        NSError *error = nil;
        fetchedRecordList = [self.conversationTable findAllWithError:&error];
        
        NSAssert(error == nil, [error localizedDescription]);
    }];
    
    return fetchedRecordList;
}`

不知道这个想法合不合适，提交给大神看下