### PR TITLE
已存在明文数据库自动加密

### DIFF
--- a/CTPersistance.xcodeproj/project.pbxproj
+++ b/CTPersistance.xcodeproj/project.pbxproj
@@ -82,6 +82,10 @@
 		4AF38F2F1F69068700801322 /* CTPersistanceTestTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AF38F2E1F69068700801322 /* CTPersistanceTestTransaction.m */; };
 		6284DE2109EF43B7A3D56F18 /* libPods-CTPersistance.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 24975DE09A62B809BFED181C /* libPods-CTPersistance.a */; };
 		DAEEF1BE411F617114764D0F /* libPods-CTPersistanceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D31FADFF56BDD50C7FD9C94 /* libPods-CTPersistanceTests.a */; };
+		F51057BA22328E7100C06D8A /* CTPersistanceTestEncrptPlaintextDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = F51057B922328E7100C06D8A /* CTPersistanceTestEncrptPlaintextDatabase.m */; };
+		F51057BD2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F51057BC2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.m */; };
+		F51057C02232932200C06D8A /* EncryptPlaintextDatabaseTestTable.m in Sources */ = {isa = PBXBuildFile; fileRef = F51057BF2232932200C06D8A /* EncryptPlaintextDatabaseTestTable.m */; };
+		F51057C2223293D000C06D8A /* EncryptPlaintextDatabaseTestTable.m in Sources */ = {isa = PBXBuildFile; fileRef = F51057BF2232932200C06D8A /* EncryptPlaintextDatabaseTestTable.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -236,6 +240,11 @@
 		89D41C6489863CB58D4966E5 /* Pods-CTPersistance.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CTPersistance.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CTPersistance/Pods-CTPersistance.debug.xcconfig"; sourceTree = "<group>"; };
 		AD102503C09A04454242FAC0 /* Pods-CTPersistanceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CTPersistanceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CTPersistanceTests/Pods-CTPersistanceTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D9D5304E203B48D737D87E6F /* Pods-CTPersistanceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CTPersistanceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CTPersistanceTests/Pods-CTPersistanceTests.release.xcconfig"; sourceTree = "<group>"; };
+		F51057B922328E7100C06D8A /* CTPersistanceTestEncrptPlaintextDatabase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTPersistanceTestEncrptPlaintextDatabase.m; sourceTree = "<group>"; };
+		F51057BB2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Target_EncryptPlaintextTestDataBase.h; sourceTree = "<group>"; };
+		F51057BC2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Target_EncryptPlaintextTestDataBase.m; sourceTree = "<group>"; };
+		F51057BE2232932200C06D8A /* EncryptPlaintextDatabaseTestTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EncryptPlaintextDatabaseTestTable.h; sourceTree = "<group>"; };
+		F51057BF2232932200C06D8A /* EncryptPlaintextDatabaseTestTable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EncryptPlaintextDatabaseTestTable.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -349,6 +358,7 @@
 				4AC74A891FBEAEBD0092B636 /* CTPersistanceTestTableIndex.m */,
 				4A76096620A16C82009908A6 /* CTPersistanceTestChangeKey.m */,
 				4AE5541320AD1F190020BAC7 /* CTPersistanceTestUpsert.m */,
+				F51057B922328E7100C06D8A /* CTPersistanceTestEncrptPlaintextDatabase.m */,
 				4A7844C41F32C1F500CF4809 /* MigrationTestModel */,
 				4A0E00441F2C384E00E6A4DA /* Info.plist */,
 			);
@@ -617,6 +627,8 @@
 			children = (
 				4A0E00BD1F2CC25A00E6A4DA /* TestTable.h */,
 				4A0E00BE1F2CC25A00E6A4DA /* TestTable.m */,
+				F51057BE2232932200C06D8A /* EncryptPlaintextDatabaseTestTable.h */,
+				F51057BF2232932200C06D8A /* EncryptPlaintextDatabaseTestTable.m */,
 			);
 			path = Table;
 			sourceTree = "<group>";
@@ -764,6 +776,8 @@
 				4A532CAE1F3C59520074BA46 /* Target_MigrationTestDatabase.m */,
 				47C1D71720A145DE00020AB5 /* Target_TestDatabase.h */,
 				47C1D71820A145DE00020AB5 /* Target_TestDatabase.m */,
+				F51057BB2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.h */,
+				F51057BC2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.m */,
 			);
 			path = ConfigurationTarget;
 			sourceTree = "<group>";
@@ -1200,6 +1214,7 @@
 				4A0E00301F2C384E00E6A4DA /* ViewController.m in Sources */,
 				4A0E00A81F2CBD6300E6A4DA /* CTPersistanceQueryCommand+Status.m in Sources */,
 				4A0E00A21F2CBD6300E6A4DA /* CTPersistanceMigrator.m in Sources */,
+				F51057C2223293D000C06D8A /* EncryptPlaintextDatabaseTestTable.m in Sources */,
 				4A0E009C1F2CBD6300E6A4DA /* NSArray+CTPersistanceRecordTransform.m in Sources */,
 				4ACE635F1F341102007F3E6D /* NSString+Where.m in Sources */,
 				4A0E00AB1F2CBD6300E6A4DA /* CTPersistanceTable+Delete.m in Sources */,
@@ -1241,6 +1256,7 @@
 				4A17A96C1F32D0C0009356D7 /* TestMiagratorVersion_3_to_4.m in Sources */,
 				4A17A9941F32F392009356D7 /* TestTableVersion1.m in Sources */,
 				47C1D71920A145DE00020AB5 /* Target_TestDatabase.m in Sources */,
+				F51057BA22328E7100C06D8A /* CTPersistanceTestEncrptPlaintextDatabase.m in Sources */,
 				4A17A9951F32F392009356D7 /* TestRecordVersion2.m in Sources */,
 				4AF38F2F1F69068700801322 /* CTPersistanceTestTransaction.m in Sources */,
 				4A76096720A16C82009908A6 /* CTPersistanceTestChangeKey.m in Sources */,
@@ -1250,6 +1266,7 @@
 				4A17A9601F32D094009356D7 /* TestMiagratorVersion_1_to_3.m in Sources */,
 				4A17A9971F32F392009356D7 /* TestRecordVersion3.m in Sources */,
 				4A0E00BF1F2CC25A00E6A4DA /* TestRecord.m in Sources */,
+				F51057C02232932200C06D8A /* EncryptPlaintextDatabaseTestTable.m in Sources */,
 				4AE5541420AD1F190020BAC7 /* CTPersistanceTestUpsert.m in Sources */,
 				4AB165E81F302AA60043E6A2 /* CTPersistanceTestFind.m in Sources */,
 				4A17A9981F32F392009356D7 /* TestTableVersion3.m in Sources */,
@@ -1261,6 +1278,7 @@
 				4A0E00C01F2CC25A00E6A4DA /* TestTable.m in Sources */,
 				4A17A9931F32F392009356D7 /* TestRecordVersion1.m in Sources */,
 				4A17A99A1F32F392009356D7 /* TestTableVersion4.m in Sources */,
+				F51057BD2232900000C06D8A /* Target_EncryptPlaintextTestDataBase.m in Sources */,
 				4A532CAF1F3C59520074BA46 /* Target_MigrationTestDatabase.m in Sources */,
 				4A51505D1F2F2402004BA79C /* CTPersistanceTestDelete.m in Sources */,
 				4A17A9691F32D0B5009356D7 /* TestMiagratorVersion_2_to_4.m in Sources */,

--- a/CTPersistanceTests/CTPersistanceTestEncrptPlaintextDatabase.m
+++ b/CTPersistanceTests/CTPersistanceTestEncrptPlaintextDatabase.m
@@ -1,0 +1,88 @@
+//
+//  CTPersistanceTestEncrptPlaintextDatabase.m
+//  CTPersistanceTests
+//
+//  Created by 周中广 on 2019/3/8.
+//  Copyright © 2019 casa. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "EncryptPlaintextDatabaseTestTable.h"
+
+NSString * const kCTPersistanceEncryptKey = @"kCTPersistanceEncryptKey";
+
+
+@interface CTPersistanceTestEncrptPlaintextDatabase : XCTestCase
+
+@end
+
+@implementation CTPersistanceTestEncrptPlaintextDatabase
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    [self clean];
+    [super tearDown];
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testEncryptPlaintextDatabase {
+    // no encryption
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kCTPersistanceEncryptKey];
+    
+    // create a plaintext database and insert three record
+    EncryptPlaintextDatabaseTestTable *insertTestTable = [[EncryptPlaintextDatabaseTestTable alloc] init];
+    TestRecord *record = [[TestRecord alloc] init];
+    record.name = @"casa";
+    
+    NSError *insertError;
+    [insertTestTable insertRecord:record error:&insertError];
+    
+    XCTAssertNil(insertError);
+    
+    // close database
+    [[CTPersistanceDatabasePool sharedInstance] closeAllDatabase];
+    
+    // open plaintext database and fetch record
+    EncryptPlaintextDatabaseTestTable *fetchTable = [[EncryptPlaintextDatabaseTestTable alloc] init];
+    
+    NSError *findError;
+    NSArray *array = [fetchTable findAllWithError:&findError];
+    XCTAssertNil(findError);
+    NSLog(@"%@", array);
+    
+    // close database
+    [[CTPersistanceDatabasePool sharedInstance] closeAllDatabase];
+    
+    // start encrypt existing plaintext database
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kCTPersistanceEncryptKey];
+    
+    // convert plaintext database to encypted database and fetch record
+    EncryptPlaintextDatabaseTestTable *encryptedFetchTable = [[EncryptPlaintextDatabaseTestTable alloc] init];
+    
+    NSError *encryptedFindError;
+    NSArray *encryptedArray = [encryptedFetchTable findAllWithError:&findError];
+    XCTAssertNil(encryptedFindError);
+    NSLog(@"%@", encryptedArray);
+}
+
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+- (void)clean {
+    NSString *filePath = [[NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:@"EncryptPlaintextTestDataBase.sqlite"];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        NSLog(@"dfjl");
+    }
+    [[NSFileManager defaultManager] removeItemAtPath:filePath error:NULL];
+}
+
+@end

--- a/CTPersistanceTests/ConfigurationTarget/Target_EncryptPlaintextTestDataBase.h
+++ b/CTPersistanceTests/ConfigurationTarget/Target_EncryptPlaintextTestDataBase.h
@@ -1,0 +1,27 @@
+//
+//  Target_EncryptPlaintextTestDataBase.h
+//  CTPersistanceTests
+//
+//  Created by 周中广 on 2019/3/8.
+//  Copyright © 2019 casa. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CTPersistance.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Target_EncryptPlaintextTestDataBase : NSObject <CTPersistanceConfigurationTarget>
+
+/**
+ secret key to encrypt the database, return nil means no encryption.
+ 
+ @param params params is a dictionary, with key kCTPersistanceConfigurationParamsKeyDatabaseName to tell you the database name
+ @return secret key
+ */
+- (NSArray *)Action_secretKey:(NSDictionary *)params;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CTPersistanceTests/ConfigurationTarget/Target_EncryptPlaintextTestDataBase.m
+++ b/CTPersistanceTests/ConfigurationTarget/Target_EncryptPlaintextTestDataBase.m
@@ -1,0 +1,32 @@
+//
+//  Target_EncryptPlaintextTestDataBase.m
+//  CTPersistanceTests
+//
+//  Created by 周中广 on 2019/3/8.
+//  Copyright © 2019 casa. All rights reserved.
+//
+
+#import "Target_EncryptPlaintextTestDataBase.h"
+
+extern NSString * const kCTPersistanceEncryptKey;
+
+@implementation Target_EncryptPlaintextTestDataBase
+
+/**
+ secret key to encrypt the database, return nil means no encryption.
+ 
+ @param params params is a dictionary, with key kCTPersistanceConfigurationParamsKeyDatabaseName to tell you the database name
+ @return secret key
+ */
+- (NSArray *)Action_secretKey:(NSDictionary *)params
+{
+    BOOL encrypt = [[NSUserDefaults standardUserDefaults] boolForKey:kCTPersistanceEncryptKey];
+
+    if (!encrypt) {// no encryption , will create a plaintext database
+        return nil;
+    } else {// convert an existing plaintext database to an encrypted database
+        return @[@"oneSecretKey"];
+    }
+}
+
+@end

--- a/CTPersistanceTests/TestModel/Table/EncryptPlaintextDatabaseTestTable.h
+++ b/CTPersistanceTests/TestModel/Table/EncryptPlaintextDatabaseTestTable.h
@@ -1,0 +1,19 @@
+//
+//  EncryptPlaintextDatabaseTestTable.h
+//  CTPersistanceTests
+//
+//  Created by 周中广 on 2019/3/8.
+//  Copyright © 2019 casa. All rights reserved.
+//
+
+#import "CTPersistanceTable.h"
+
+#import "TestRecord.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EncryptPlaintextDatabaseTestTable : CTPersistanceTable <CTPersistanceTableProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CTPersistanceTests/TestModel/Table/EncryptPlaintextDatabaseTestTable.m
+++ b/CTPersistanceTests/TestModel/Table/EncryptPlaintextDatabaseTestTable.m
@@ -1,0 +1,45 @@
+//
+//  EncryptPlaintextDatabaseTestTable.m
+//  CTPersistanceTests
+//
+//  Created by 周中广 on 2019/3/8.
+//  Copyright © 2019 casa. All rights reserved.
+//
+
+#import "EncryptPlaintextDatabaseTestTable.h"
+
+
+@implementation EncryptPlaintextDatabaseTestTable
+
+#pragma mark - CTPersistanceTableProtocol
+- (NSString *)tableName
+{
+    return @"encryptPlaintextDatabaseTest";
+}
+
+- (NSString *)databaseName
+{
+    return @"EncryptPlaintextTestDataBase.sqlite";
+}
+
+- (NSDictionary *)columnInfo
+{
+    return @{
+             @"primaryKey":@"INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL",
+             @"name":@"TEXT",
+             @"age":@"INTEGER",
+             };
+}
+
+- (Class)recordClass
+{
+    return [TestRecord class];
+}
+
+- (NSString *)primaryKeyName
+{
+    return @"primaryKey";
+}
+
+
+@end


### PR DESCRIPTION
增加了已存在未加密的本地数据库文件的情况下，自动转换已有明文数据库成加密数据的功能

修改背景：
上次发现已有明文数据库无法直接加密，然后就网上找了下，找到了SQLCipher库的开发人员给的操作建议[How to encrypt a plaintext SQLite database to use SQLCipher (and avoid “file is encrypted or is not a database” errors)](https://discuss.zetetic.net/t/how-to-encrypt-a-plaintext-sqlite-database-to-use-sqlcipher-and-avoid-file-is-encrypted-or-is-not-a-database-errors/868)。自己考虑了一下，虽然在CTPersistance库外部也可以进行这个操作，但是本地数据库的命名、路径都是跟CTPersistance相关的，而且直觉来说库集成这个能力感觉库也更完善一些，就按照说明实现了一下从已有明文数据库使用SQLCipher加密的功能，经测试确实可用，提交给你看下

具体步骤：
1、如果返回只有一个key值 && 这个key不能解密本地数据库文件，执行第2步
2、使用已有明文数据库生成一个加密数据库，并把所有数据库数据导出到新的加密数据库
具体实现：
$ ./sqlcipher plaintext.db
sqlite> ATTACH DATABASE 'encrypted.db' AS encrypted KEY 'newkey';
sqlite> SELECT sqlcipher_export('encrypted');
sqlite> DETACH DATABASE encrypted;

3、关闭打开的明文数据库，然后移除明文数据库文件，并重命名新的加密数据库文件为原有数据库文件名
4、重新打开密文数据库，并设置key值